### PR TITLE
fix: improve video title and author name extraction regex 

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,13 +55,13 @@ export const DEFAULT_SETTINGS: PluginSettings = {
 };
 
 // Regex pattern for extracting video title from meta tag
-export const TITLE_REGEX = /"title":"([^"]+)"/;
+export const TITLE_REGEX = /"title":"((?:[^"\\]|\\"|\\\\)+)"/;
 
 // Regex pattern for extracting video ID from YouTube URL
 export const VIDEO_ID_REGEX = /(?:v=|\/)([a-zA-Z0-9_-]{11})/;
 
 // Regex pattern for extracting video author from meta tag
-export const AUTHOR_REGEX = /"author":"([^"]+)"/;
+export const AUTHOR_REGEX = /"author":"((?:[^"\\]|\\"|\\\\)+)"/;
 
 // Regex pattern for extracting channel ID from video page
 export const CHANNEL_ID_REGEX = /"channelId":"([^"]+)"/;


### PR DESCRIPTION
to handle double quotes and backslashes